### PR TITLE
npm ci over npm install for prod builds 

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install --silent
+RUN npm ci --silent
 
 ARG API_URL
 ENV REACT_APP_API_URL=$API_URL


### PR DESCRIPTION
Using `npm ci` instead of `npm install` for production builds offers several advantages:

1. **Consistency**: `npm ci` installs dependencies exactly as specified in the `package-lock.json` file, ensuring a consistent and reproducible environment.
2. **Speed**: `npm ci` is generally faster than `npm install` since it skips certain steps, like generating a new `package-lock.json` file.
3. **Clean slate**: `npm ci` removes the `node_modules` folder before installing dependencies, ensuring no leftover files or packages from previous installations.

These benefits contribute to more reliable and faster build processes, especially critical in production environments.